### PR TITLE
chore: change of ownership from developer-productivity to platform-ops

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: other
   lifecycle: production
-  owner: 'developer-productivity'
+  owner: 'platform-ops'


### PR DESCRIPTION
This PR changes the ownership of this repo to platform-ops, as the developer productivity team doesn't exist anymore.